### PR TITLE
Adding support for genre tagging for non-gracenote integrated partners

### DIFF
--- a/AndroidTvSampleInput/app/src/main/java/com/example/android/sampletvinput/SampleJobService.java
+++ b/AndroidTvSampleInput/app/src/main/java/com/example/android/sampletvinput/SampleJobService.java
@@ -27,6 +27,7 @@ import com.google.android.media.tv.companionlibrary.XmlTvParser;
 import com.google.android.media.tv.companionlibrary.model.Channel;
 import com.google.android.media.tv.companionlibrary.model.InternalProviderData;
 import com.google.android.media.tv.companionlibrary.model.Program;
+import com.google.android.media.tv.companionlibrary.model.TifExtension;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,6 +51,19 @@ public class SampleJobService extends EpgSyncJobService {
     private String MPEG_DASH_PROGRAM_URL
             = "http://ecx.images-amazon.com/images/I/61aoo6-ulML.png";
     private int MPEG_DASH_ORIGINAL_NETWORK_ID = 101;
+
+    private static final String SPORTS_GENRE = "Sports";
+    private List<String> GENRE_CHANNEL_NAMES = Arrays.asList(
+            "Genre Channel 1",
+            "Genre Channel 2",
+            "Genre Channel 3",
+            "Genre Channel 4",
+            "Genre Channel 5");
+
+    private String GENRE_CHANNEL_LOGO
+            = "http://ecx.images-amazon.com/images/I/21tj+38IfML.png";
+    private String GENRE_PROGRAM_URL
+            = "http://ecx.images-amazon.com/images/I/61TnDMKesdL.png";
     private String TEARS_OF_STEEL_TITLE = "Tears of Steel";
     private String TEARS_OF_STEEL_DESCRIPTION = "Monsters invade a small town in this sci-fi flick";
     private String TEARS_OF_STEEL_ART
@@ -99,16 +113,17 @@ public class SampleJobService extends EpgSyncJobService {
      * This is a sample implementation of getChannels() which shows how to retrieve channels from an
      * XML resource file and create programmatically inline.
      *
-     * There are 8 channels retrieved here and then inserted into the TIF Database.
+     * There are 13 channels retrieved here and then inserted into the TIF Database.
      *
      * Channels 1, 2 and 3 are retrieved from the resource XML file: rich_tv_input_xmltv_feed.xml
-     * Channels 4 - 8 are created programmatically in this method.
+     * Channels 4 - 13 are created programmatically in this method. Channels 9-13 will also appear on
+     * Genre row in the Live Tab, if Live Tab is available in the Marketplace.
      *
      * Channels 1 and 2 are deeplink integrated meaning we insert a URI to launch this app
      * to playback content in a custom player. This URI is invoked when a user selects the channel
      * in the Fire TV UI.
      *
-     * Channels 3 and 4 are integrated with the Fire TV Native Player meaning they will be played
+     * Channels 3, 4 and 9-13 are integrated with the Fire TV Native Player meaning they will be played
      * as part of the Fire TV UI - this uses the same mechanism used to implement preview playback.
      *
      * Channels 5 - 8 are integrated with external metadata meaning these channels receive all
@@ -176,34 +191,79 @@ public class SampleJobService extends EpgSyncJobService {
             channelList.add(externalMetadataChannel);
         }
 
+        //Add channel programmatically with Genre information
+        List<Channel> genreChannels = Arrays.asList(
+                new Channel.Builder()
+                        .setDisplayName(GENRE_CHANNEL_NAMES.get(0))
+                        .setDisplayNumber("9")
+                        .setChannelLogo(GENRE_CHANNEL_LOGO)
+                        .setOriginalNetworkId(110)
+                        .setTifExtension(new TifExtension.Builder()
+                                .setGenre(SPORTS_GENRE)
+                                .build())
+                        .build(),
+                new Channel.Builder()
+                        .setDisplayName(GENRE_CHANNEL_NAMES.get(1))
+                        .setDisplayNumber("10")
+                        .setChannelLogo(GENRE_CHANNEL_LOGO)
+                        .setOriginalNetworkId(111)
+                        .setTifExtension(new TifExtension.Builder()
+                                .setGenre(SPORTS_GENRE)
+                                .build())
+                        .build(),
+                new Channel.Builder()
+                        .setDisplayName(GENRE_CHANNEL_NAMES.get(2))
+                        .setDisplayNumber("11")
+                        .setChannelLogo(GENRE_CHANNEL_LOGO)
+                        .setOriginalNetworkId(112)
+                        .setTifExtension(new TifExtension.Builder()
+                                .setGenre(SPORTS_GENRE)
+                                .build())
+                        .build(),
+                new Channel.Builder()
+                        .setDisplayName(GENRE_CHANNEL_NAMES.get(3))
+                        .setDisplayNumber("12")
+                        .setChannelLogo(GENRE_CHANNEL_LOGO)
+                        .setOriginalNetworkId(113)
+                        .setTifExtension(new TifExtension.Builder()
+                                .setGenre(SPORTS_GENRE)
+                                .build())
+                        .build(),
+                new Channel.Builder()
+                        .setDisplayName(GENRE_CHANNEL_NAMES.get(4))
+                        .setDisplayNumber("13")
+                        .setChannelLogo(GENRE_CHANNEL_LOGO)
+                        .setOriginalNetworkId(114)
+                        .setTifExtension(new TifExtension.Builder()
+                                .setGenre(SPORTS_GENRE)
+                                .build())
+                        .build()
+        );
+        channelList.addAll(genreChannels);
+
         return channelList;
     }
 
     @Override
     public List<Program> getProgramsForChannel(Uri channelUri, Channel channel, long startMs,
-            long endMs) {
+                                               long endMs) {
+        // Programmatically add channel
+        List<Program> programsTears = new ArrayList<>();
+        InternalProviderData internalProviderData = new InternalProviderData();
+        internalProviderData.setVideoType(Util.TYPE_DASH);
+        internalProviderData.setVideoUrl(TEARS_OF_STEEL_SOURCE);
+
+        String description;
+        String thumbnail;
+
         if (channel.getDisplayName().equals(MPEG_DASH_CHANNEL_NAME)) {
-            // Programmatically add channel
-            List<Program> programsTears = new ArrayList<>();
-            InternalProviderData internalProviderData = new InternalProviderData();
-            internalProviderData.setVideoType(Util.TYPE_DASH);
-            internalProviderData.setVideoUrl(TEARS_OF_STEEL_SOURCE);
-
-            programsTears.add(new Program.Builder()
-                    .setTitle(TEARS_OF_STEEL_TITLE)
-                    .setStartTimeUtcMillis(TEARS_OF_STEEL_START_TIME_MS)
-                    .setEndTimeUtcMillis(TEARS_OF_STEEL_START_TIME_MS + TEARS_OF_STEEL_DURATION_MS)
-                    .setDescription(TEARS_OF_STEEL_DESCRIPTION)
-                    .setCanonicalGenres(new String[] {TvContract.Programs.Genres.TECH_SCIENCE,
-                            TvContract.Programs.Genres.MOVIES})
-                    .setContentRatings(new TvContentRating[]{TvContentRating.createRating(ANDROID_TV_RATING,"US_TV", "US_TV_PG")})
-                    .setPosterArtUri(TEARS_OF_STEEL_ART)
-                    .setThumbnailUri(MPEG_DASH_PROGRAM_URL)
-                    .setInternalProviderData(internalProviderData)
-                    .build());
-
-            return programsTears;
-        } else if (channel.getInternalProviderData() != null && channel.getInternalProviderData().getExternalIdValue() != null) {
+            description = TEARS_OF_STEEL_DESCRIPTION;
+            thumbnail = MPEG_DASH_PROGRAM_URL;
+        } else if (GENRE_CHANNEL_NAMES.contains(channel.getDisplayName())) {
+            description = "Program for genre tagged channel: " + TEARS_OF_STEEL_DESCRIPTION;
+            thumbnail = GENRE_PROGRAM_URL;
+        } else if (channel.getInternalProviderData() != null && channel.getInternalProviderData()
+                .getExternalIdValue() != null) {
             // Has external metadata provided , no need to insert programs
             return Collections.emptyList();
         } else {
@@ -211,5 +271,19 @@ public class SampleJobService extends EpgSyncJobService {
             XmlTvParser.TvListing listings = RichFeedUtil.getRichTvListings(getApplicationContext());
             return listings.getPrograms(channel);
         }
+        programsTears.add(new Program.Builder()
+                    .setTitle(TEARS_OF_STEEL_TITLE)
+                    .setStartTimeUtcMillis(TEARS_OF_STEEL_START_TIME_MS)
+                    .setEndTimeUtcMillis(TEARS_OF_STEEL_START_TIME_MS + TEARS_OF_STEEL_DURATION_MS)
+                    .setDescription(description)
+                    .setCanonicalGenres(new String[] {TvContract.Programs.Genres.TECH_SCIENCE,
+                            TvContract.Programs.Genres.MOVIES})
+                    .setContentRatings(new TvContentRating[]{TvContentRating.createRating(ANDROID_TV_RATING,
+                            "US_TV", "US_TV_PG")})
+                    .setPosterArtUri(TEARS_OF_STEEL_ART)
+                    .setThumbnailUri(thumbnail)
+                    .setInternalProviderData(internalProviderData)
+                    .build());
+            return programsTears;
     }
 }

--- a/AndroidTvSampleInput/library/src/main/AndroidManifest.xml
+++ b/AndroidTvSampleInput/library/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="com.android.providers.tv.permission.READ_EPG_DATA" />
     <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />
+    <!-- This element is used to request read and write access to the TifExtension ContentProvider -->
+    <uses-permission android:name="com.amazon.tv.permission.TIF_EXTENSION_ACCESS"/>
 
     <application/>
 </manifest>

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/model/Channel.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/model/Channel.java
@@ -59,6 +59,7 @@ public final class Channel {
     private String mNetworkAffiliation;
     private int mSearchable;
     private String mServiceType;
+    private TifExtension mTifExtension;
 
     private Channel() {
         mId = INVALID_CHANNEL_ID;
@@ -192,6 +193,11 @@ public final class Channel {
     public String getNetworkAffiliation() {
         return mNetworkAffiliation;
     }
+
+    /**
+     * @return An instance of {@Link TIFExtension} for the channel
+     */
+    public TifExtension getTifExtension() { return mTifExtension; }
 
     /**
      * @return The value of {@link TvContract.Channels#COLUMN_SEARCHABLE} for the channel.
@@ -358,6 +364,7 @@ public final class Channel {
         mNetworkAffiliation = other.mNetworkAffiliation;
         mSearchable = other.mSearchable;
         mServiceType = other.mServiceType;
+        mTifExtension = other.mTifExtension;
     }
 
     /**
@@ -768,6 +775,17 @@ public final class Channel {
          */
         public Builder setServiceType(String serviceType) {
             mChannel.mServiceType = serviceType;
+            return this;
+        }
+
+        /**
+         * Sets TifExtension instance for the Channel.
+         *
+         * @param mTifExtension The instance of TifExtension for the channel.
+         * @return This Builder object to allow for chaining of calls to builder methods.
+         */
+        public Builder setTifExtension(TifExtension mTifExtension) {
+            mChannel.mTifExtension = mTifExtension;
             return this;
         }
 

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/model/TifExtension.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/model/TifExtension.java
@@ -1,0 +1,42 @@
+package com.google.android.media.tv.companionlibrary.model;
+
+import com.google.android.media.tv.companionlibrary.utils.TifExtensionContract;
+
+/**
+ * A convenience class to create TifExtension object for a TifExtension channel.
+ */
+public class TifExtension {
+    private String mGenre;
+
+    private TifExtension(Builder builder) {
+        mGenre = builder.genre;
+    }
+
+    /**
+     * @return The value of {@link TifExtensionContract.Channels#COLUMN_GENRE} for the channel.
+     */
+    public String getGenre() { return mGenre; }
+
+    public static class Builder {
+
+        private String genre;
+
+        /**
+         * Sets the genre of the channel.
+         * Currently supports 'News' and 'Sports' genre values. For up-to-date Genre values,
+         * check the documentation hub https://developer.amazon.com/docs//fire-tv/live-tv-resources.html
+         * or ask your Amazon contact for the latest list.
+         *
+         * @param genre The genre corresponding to the channel.
+         * @return This Builder object to allow for chaining of calls to builder methods.
+         */
+        public Builder setGenre(String genre) {
+            this.genre = genre;
+            return this;
+        }
+
+        public TifExtension build() {
+            return new TifExtension(this);
+        }
+    }
+}

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/utils/TifExtensionChannel.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/utils/TifExtensionChannel.java
@@ -1,0 +1,76 @@
+package com.google.android.media.tv.companionlibrary.utils;
+
+import com.google.android.media.tv.companionlibrary.model.TifExtension;
+
+/**
+ * A convenience class to create and insert TifExtension channel entries into the database.
+ */
+public class TifExtensionChannel {
+    private String inputId;
+    private long channelId;
+    private TifExtension tifExtension;
+
+    private TifExtensionChannel(Builder builder) {
+        inputId = builder.inputId;
+        channelId = builder.channelId;
+        tifExtension = builder.tifExtension;
+    }
+
+    /**
+     * @return The value of {@link TifExtensionContract.Channels#COLUMN_INPUT_ID} for the channel.
+     */
+    public String getInputId() { return inputId; }
+
+    /**
+     * @return The value of {@link TifExtensionContract.Channels#COLUMN_CHANNEL_ID} for the channel.
+     */
+    public long getChannelId() { return channelId; }
+
+    /**
+     * @return The value of {@link TifExtension} for the channel.
+     */
+    public TifExtension getTifExtension() { return tifExtension; }
+
+    public static class Builder {
+        private String inputId;
+        private long channelId;
+        private TifExtension tifExtension;
+
+        /**
+         * Sets the Input Id of the Channel.
+         *
+         * @param inputId The value of {@link TifExtensionContract.Channels#COLUMN_INPUT_ID}
+         *               for the channel.
+         * @return This Builder object to allow for chaining of calls to builder methods.
+         */
+        public Builder setInputId(String inputId) {
+            this.inputId = inputId;
+            return this;
+        }
+
+        /**
+         * Sets the Channel Id of the Channel using the channel URI.
+         *
+         * @param channelId The value of {@link TifExtensionContract.Channels#COLUMN_CHANNEL_ID}
+         *               for the channel using channel Uri.
+         * @return This Builder object to allow for chaining of calls to builder methods.
+         */
+        public Builder setChannelId(long channelId) {
+            this.channelId = channelId;
+            return this;
+        }
+
+        /**
+         * Sets the TifExtensions instance for the channel.
+         *
+         * @param tifExtension The value of {@link TifExtension} for the channel.
+         * @return This Builder object to allow for chaining of calls to builder methods.
+         */
+        public Builder setTifExtension(TifExtension tifExtension) {
+            this.tifExtension = tifExtension;
+            return this;
+        }
+
+        public TifExtensionChannel build() { return new TifExtensionChannel(this); }
+    }
+}

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/utils/TifExtensionContract.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/utils/TifExtensionContract.java
@@ -1,0 +1,50 @@
+package com.google.android.media.tv.companionlibrary.utils;
+
+import android.net.Uri;
+
+/**
+ * The TifExtension contract between the TV provider and Live Tv app
+ */
+public class TifExtensionContract {
+    /**
+     * The authority for the TifExtension Provider
+     */
+    public final static String AUTHORITY = "com.amazon.tv.livetv.tifextension";
+
+
+    private static final String PATH_CHANNEL = "channel";
+
+
+    public static final class Channels {
+
+        /**
+         * The content:// style URI for channel table.
+         */
+        public final static Uri CONTENT_URI = Uri.parse("content://" + AUTHORITY + "/" + PATH_CHANNEL);
+
+        //============= Columns ==============//
+
+        /**
+         * Matches to input_id in TvContract.Channel table
+         * This is a required field. @NonNull
+         * Type: TEXT
+         */
+        public final static String COLUMN_INPUT_ID = "input_id";
+
+        /**
+         * Matches to channel_id in TvContract.Channel table
+         * This is a required field. @NonNull
+         * Type: TEXT
+         */
+        public final static String COLUMN_CHANNEL_ID = "channel_id";
+
+        /**
+         * The comma-separated genre string of this channel.
+         * Channel with valid genre values will show inside corresponding Genre rows under LiveTab
+         * Valid genre value is defined in the contract.
+         * Invalid value would be ignored.
+         * Type: TEXT Default Null
+         */
+        public final static String COLUMN_GENRE = "genre";
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Currently genre tagging functionality is only available for gracenote integrated partners. This change will enable the genre tagging for non-gracenote integrated partners as well. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
