### PR TITLE
Adding additional documentation for INITIALIZE_PROGRAMS usage

### DIFF
--- a/AndroidTvSampleInput/app/src/main/AndroidManifest.xml
+++ b/AndroidTvSampleInput/app/src/main/AndroidManifest.xml
@@ -110,7 +110,12 @@
             </intent-filter>
         </receiver>
 
-        <receiver android:name=".InitializationReceiver">
+        <!-- INITIALIZE_PROGRAMS is sent out after app has been installed.
+        This receiver can be used to sync channels data to the device (TIF database)
+        before opening the app. -->
+        <receiver android:name=".InitializationReceiver"
+            android:exported="true"
+            >
             <intent-filter>
                 <action android:name="android.media.tv.action.INITIALIZE_PROGRAMS" />
             </intent-filter>

--- a/AndroidTvSampleInput/app/src/main/java/com/example/android/sampletvinput/InitializationReceiver.java
+++ b/AndroidTvSampleInput/app/src/main/java/com/example/android/sampletvinput/InitializationReceiver.java
@@ -4,16 +4,33 @@ import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
+
 import com.google.android.media.tv.companionlibrary.utils.TvContractUtils;
 
 /**
  * Run when the input should initialize its content.
  */
 public class InitializationReceiver extends BroadcastReceiver {
-    private static final String TAG = "InitializationReceiver";
+    private static final String TAG = InitializationReceiver.class.getSimpleName();
 
+    /**
+     * Receives intent with action INITIALIZE_PROGRAMS which is broadcast after installation.
+     * This can be leveraged to sync channel data to the device (TIF database) after
+     * installation without opening the application. Use the below commands to see the relevant
+     * logs:
+     *
+     * adb logcat TvInputChangeReceiver:D TvContractUtils:D InitializationReceiver:D *:S
+     *
+     * Since INITIALIZE_PROGRAMS is only sent when the app is installed/sideloaded,
+     * you can quickly retest the receiver/initialization logic using the command below:
+     *
+     * adb shell am broadcast -a android.media.tv.action.INITIALIZE_PROGRAMS -n \
+     * com.example.android.sampletvinput/.InitializationReceiver
+     * */
     @Override
     public void onReceive(Context context, Intent intent) {
+        Log.d(TAG, "Received intent with action " + intent.getAction());
         SampleJobService.requestImmediateSync(context, TvContractUtils.INPUT_ID, new ComponentName(context, SampleJobService.class));
     }
 }


### PR DESCRIPTION
*Description of changes:*

Code changes have already been implemented:
- https://code.amazon.com/packages/AndroidTvSampleInput/blobs/3593df731a1e584a2d8975e260431ecd55db79f5/--/AndroidTvSampleInput/app/src/main/java/com/example/android/sampletvinput/InitializationReceiver.java#L16

- https://code.amazon.com/packages/AndroidTvSampleInput/blobs/aeaaf4477486e8a55a56b7d0107e9a089a7d7bf3/--/AndroidTvSampleInput/app/src/main/AndroidManifest.xml#L113

This CR adds additional comments to describe usage of INITIALIZE_PROGRAMS

*Testing:*
Verified in the logs that INITIALIZE_PRORGAMS gets sent when sample app is installed

`adb logcat TvInputChangeReceiver:D TvContractUtils:D InitializationReceiver:D TIFUtils:D *:S`

```
09-22 10:12:17.066 12499 12499 I TvInputChangeReceiver: Received TvInput change event: com.amazon.tv.action.TV_INPUT_ADDED, for input: com.example.android.sampletvinput/.rich.RichTvInputService
09-22 10:12:17.078 12499 12499 I TIFUtils: Sending initialization intent for com.example.android.sampletvinput
09-22 10:12:18.134 12768 12768 D InitializationReceiver: Received intent with action android.media.tv.action.INITIALIZE_PROGRAMS
09-22 10:12:18.589 12768 12797 D TvContractUtils: Adding channel -941324943 at content://android.media.tv/channel/32
...
...
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
