### PR TITLE
Updating tif insertion logic to only update channels if there is a delta

### DIFF
--- a/AndroidTvSampleInput/library/build.gradle
+++ b/AndroidTvSampleInput/library/build.gradle
@@ -27,6 +27,9 @@ android {
             minifyEnabled false
         }
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 configurations {

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/EpgSyncJobService.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/EpgSyncJobService.java
@@ -41,6 +41,7 @@ import android.util.SparseArray;
 import com.google.android.media.tv.companionlibrary.model.Channel;
 import com.google.android.media.tv.companionlibrary.model.InternalProviderData;
 import com.google.android.media.tv.companionlibrary.model.Program;
+import com.google.android.media.tv.companionlibrary.utils.ChannelDao;
 import com.google.android.media.tv.companionlibrary.utils.TvContractUtils;
 
 import junit.framework.Assert;

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/model/Channel.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/model/Channel.java
@@ -25,6 +25,9 @@ import android.text.TextUtils;
 
 import com.google.android.media.tv.companionlibrary.utils.CollectionUtils;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 /**
  * A convenience class to create and insert channel entries into the database.
  */
@@ -260,7 +263,7 @@ public final class Channel {
      * TV Input Framework database.
      * @hide
      */
-    public ContentValues toContentValues() {
+    public ContentValues toContentValues(String inputId, String packageName) {
         ContentValues values = new ContentValues();
         if (mId != INVALID_CHANNEL_ID) {
             values.put(TvContract.Channels._ID, mId);
@@ -268,17 +271,17 @@ public final class Channel {
         if (!TextUtils.isEmpty(mPackageName)) {
             values.put(TvContract.Channels.COLUMN_PACKAGE_NAME, mPackageName);
         } else {
-            values.putNull(TvContract.Channels.COLUMN_PACKAGE_NAME);
+            values.put(TvContract.Channels.COLUMN_PACKAGE_NAME, packageName);
         }
         if (!TextUtils.isEmpty(mInputId)) {
             values.put(TvContract.Channels.COLUMN_INPUT_ID, mInputId);
         } else {
-            values.putNull(TvContract.Channels.COLUMN_INPUT_ID);
+            values.put(TvContract.Channels.COLUMN_INPUT_ID, inputId);
         }
         if (!TextUtils.isEmpty(mType)) {
             values.put(TvContract.Channels.COLUMN_TYPE, mType);
         } else {
-            values.putNull(TvContract.Channels.COLUMN_TYPE);
+            values.put(TvContract.Channels.COLUMN_TYPE, TvContract.Channels.TYPE_OTHER);
         }
         if (!TextUtils.isEmpty(mDisplayNumber)) {
             values.put(TvContract.Channels.COLUMN_DISPLAY_NUMBER, mDisplayNumber);
@@ -474,6 +477,24 @@ public final class Channel {
         return baseColumns;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Channel channel = (Channel) o;
+        return mOriginalNetworkId == channel.mOriginalNetworkId
+                && mTransportStreamId == channel.mTransportStreamId
+                && mServiceId == channel.mServiceId
+                && mSearchable == channel.mSearchable
+                && Objects.equals(mDisplayNumber, channel.mDisplayNumber)
+                && Objects.equals(mDisplayName, channel.mDisplayName)
+                && Objects.equals(mDescription, channel.mDescription)
+                && Objects.equals(mVideoFormat, channel.mVideoFormat)
+                && Arrays.equals(mInternalProviderData, channel.mInternalProviderData)
+                && Objects.equals(mNetworkAffiliation, channel.mNetworkAffiliation)
+                && Objects.equals(mServiceType, channel.mServiceType);
+    }
+
     /**
      * The builder class that makes it easy to chain setters to create a {@link Channel} object.
      */
@@ -495,7 +516,7 @@ public final class Channel {
          * @param id The value of {@link TvContract.Channels#_ID} for the channel.
          * @return This Builder object to allow for chaining of calls to builder methods.
          */
-        private Builder setId(long id) {
+        public Builder setId(long id) {
             mChannel.mId = id;
             return this;
         }

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/utils/ChannelDao.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/utils/ChannelDao.java
@@ -1,0 +1,136 @@
+package com.google.android.media.tv.companionlibrary.utils;
+
+import android.content.ContentProviderOperation;
+import android.content.ContentProviderResult;
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.media.tv.TvContract;
+import android.net.Uri;
+import android.util.Log;
+import android.util.LongSparseArray;
+
+import com.google.android.media.tv.companionlibrary.model.Channel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChannelDao {
+
+    private static final String TAG = ChannelDao.class.getSimpleName();
+
+    public static void insertChannels(ContentResolver contentResolver, LongSparseArray<Channel> insertChannels, String inputId, String packageName) {
+        List<ContentValues> contentValues = ConverterUtils.convertToContentValues(insertChannels, inputId, packageName);
+        bulkInsert(contentResolver, contentValues, TvContract.Channels.CONTENT_URI);
+    }
+
+    public static void insertTifExtensionChannels(ContentResolver contentResolver, List<TifExtensionChannel> tifExtensionChannels) {
+        List<ContentValues> tifExtensionContentValues = ConverterUtils.convertToTifExtensionContentValues(tifExtensionChannels);
+        Log.d(TAG, "Received " + tifExtensionChannels.size() + " tif extension channels to be added");
+        bulkInsert(contentResolver, tifExtensionContentValues, TifExtensionContract.Channels.CONTENT_URI);
+    }
+
+    public static void upsertChannels(ContentResolver contentResolver, LongSparseArray<Channel> insertChannels, LongSparseArray<Channel> updateChannels, String inputId, String packageName) {
+        List<ContentValues> insertContentValues = ConverterUtils.convertToContentValues(insertChannels, inputId, packageName);
+        List<ContentValues> updateContentValues = ConverterUtils.convertToContentValues(updateChannels, inputId, packageName);
+
+        Log.d(TAG, "Received " + (insertContentValues.size() + updateContentValues.size()) + " channels to be upserted");
+        ArrayList<ContentProviderOperation> bulkOperations = ConverterUtils.convertToInsertContentProviderOperation(insertContentValues);
+        bulkOperations.addAll(ConverterUtils.convertToUpdateContentProviderOperation(updateContentValues));
+
+        applyBulkOperations(contentResolver, bulkOperations, TvContract.AUTHORITY);
+    }
+
+    private static void bulkInsert(ContentResolver contentResolver, List<ContentValues> contentValues, Uri uri) {
+        try {
+            // Bulk insertion into desired table specified by Uri
+            ContentValues[] insertBulk = contentValues.toArray(new ContentValues[0]);
+            int rowsCreated = contentResolver.bulkInsert(uri, insertBulk);
+            Log.d(TAG, "Successfully added " + rowsCreated + " channels to " + uri.toString());
+        } catch (Exception e) {
+            Log.e(TAG, "Exception in bulk inserting channels", e);
+        }
+    }
+
+    private static void applyBulkOperations(ContentResolver contentResolver, ArrayList<ContentProviderOperation> bulkOperations, String authority) {
+        if (bulkOperations.size() > 0) {
+            try {
+                ContentProviderResult[] results = contentResolver.applyBatch(
+                        authority,
+                        bulkOperations
+                );
+                Log.d(TAG, "Successfully applied bulk operation for " + results.length + " channels");
+            } catch (Exception e) {
+                Log.e(TAG, "Exception in applying bulk operation", e);
+            }
+        } else {
+            Log.d(TAG, "No channels provided");
+        }
+    }
+
+    public static void deleteChannels(ContentResolver contentResolver, List<Long> deletedChannelIds) {
+        Log.d(TAG, "Received " + deletedChannelIds.size() + " channels to delete");
+        applyBulkOperations(contentResolver, ConverterUtils.convertToDeleteContentProviderOperation(deletedChannelIds), TvContract.AUTHORITY);
+    }
+
+    public static void deleteAllChannels(ContentResolver contentResolver) {
+        int rowsDeleted = contentResolver.delete(TvContract.Channels.CONTENT_URI, null, null);
+        Log.d(TAG, "Deleted " + rowsDeleted + " channels from the DB");
+    }
+
+    public static List<Channel> getAllChannels(ContentResolver contentResolver) {
+        List<Channel> channels = new ArrayList<>();
+        // TvProvider returns programs in chronological order by default.
+        try (Cursor cursor = contentResolver.query(TvContract.Channels.CONTENT_URI, Channel.PROJECTION, null, null, null)) {
+            if (cursor == null) {
+                Log.w(TAG, "Null cursor, TIF state is unknown");
+                return null;
+            }
+
+            if (cursor.getCount() == 0) {
+                Log.d(TAG, "No channels were found");
+                return channels;
+            }
+
+            while (cursor.moveToNext()) {
+                Channel channel = Channel.fromCursor(cursor);
+                channels.add(channel);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to get channels", e);
+            e.printStackTrace();
+            return null;
+        }
+
+        Log.d(TAG, "Retrieved " + channels.size() + " from the database");
+        return channels;
+    }
+
+    public static void updateChannel(ContentResolver contentResolver, Channel updatedChannel, Long rowId, String inputId, String packageName) {
+        ContentValues contentValues = updatedChannel.toContentValues(inputId, packageName);
+        contentValues.put(TvContract.Channels._ID, rowId);
+        contentResolver.update(TvContract.buildChannelUri(rowId), contentValues, null, null);
+        Log.d(TAG, "Update channel with network id " + updatedChannel.getOriginalNetworkId());
+    }
+
+    /**
+     * Returns the {@link Channel} with specified channel URI.
+     *
+     * @param channelUri URI of channel.
+     * @return An channel object with specified channel URI.
+     * @hide
+     */
+    public static Channel getChannel(ContentResolver contentResolver, Uri channelUri) {
+        try (Cursor cursor = contentResolver.query(channelUri, Channel.PROJECTION, null, null, null)) {
+            if (cursor == null || cursor.getCount() == 0) {
+                Log.w(TAG, "No channel matches " + channelUri);
+                return null;
+            }
+            cursor.moveToNext();
+            return Channel.fromCursor(cursor);
+        } catch (Exception e) {
+            Log.w(TAG, "Unable to get the channel with URI " + channelUri, e);
+            return null;
+        }
+    }
+}

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/utils/ConverterUtils.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/utils/ConverterUtils.java
@@ -1,0 +1,103 @@
+package com.google.android.media.tv.companionlibrary.utils;
+
+import android.content.ContentProviderOperation;
+import android.content.ContentValues;
+import android.media.tv.TvContract;
+import android.util.Log;
+import android.util.LongSparseArray;
+
+import com.google.android.media.tv.companionlibrary.model.Channel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConverterUtils {
+
+    private static final String TAG = ConverterUtils.class.getSimpleName();
+
+    public static List<ContentValues> convertToContentValues(LongSparseArray<Channel> channels, String inputId, String packageName) {
+        List<ContentValues> desiredContentValues = new ArrayList<>();
+
+        for (int i = 0; i < channels.size(); i++) {
+            long key = channels.keyAt(i);
+            Channel channel = channels.get(key);
+            desiredContentValues.add(channel.toContentValues(inputId, packageName));
+        }
+
+        return desiredContentValues;
+    }
+
+    public static List<ContentValues> convertToTifExtensionContentValues(List<TifExtensionChannel> tifExtensionChannels) {
+        List<ContentValues> newContentValues = new ArrayList<>();
+
+        for (TifExtensionChannel tifExtensionChannel : tifExtensionChannels) {
+            newContentValues.add(tifExtensionChannel.toContentValues());
+
+        }
+
+        return newContentValues;
+    }
+
+    public static List<TifExtensionChannel> convertToTifExtensionChannel(List<Channel> currentTifChannels, LongSparseArray<Channel> desiredChannels) {
+        List<TifExtensionChannel> tifExtensionChannels = new ArrayList<>();
+
+        for (Channel tifChannel : currentTifChannels) {
+            Channel lookupChannel = desiredChannels.get(tifChannel.getOriginalNetworkId());
+            if (lookupChannel != null && lookupChannel.getTifExtension() != null) {
+                TifExtensionChannel tifExtensionChannel = new TifExtensionChannel.Builder()
+                        .setChannelId(tifChannel.getId())
+                        .setInputId(tifChannel.getInputId())
+                        .setTifExtension(lookupChannel.getTifExtension())
+                        .build();
+                Log.d(TAG, "Found TIF extension channel with ID " + tifChannel.getId() + " and genre " + lookupChannel.getTifExtension().getGenre());
+                tifExtensionChannels.add(tifExtensionChannel);
+            }
+        }
+
+        return tifExtensionChannels;
+    }
+
+    public static ArrayList<ContentProviderOperation> convertToUpdateContentProviderOperation(List<ContentValues> contentValues) {
+        ArrayList<ContentProviderOperation> contentProviderOperations = new ArrayList<>();
+
+        for (ContentValues contentValue : contentValues) {
+            contentProviderOperations.add(
+                    ContentProviderOperation
+                            .newUpdate(TvContract.buildChannelUri((Long) contentValue.get(TvContract.Channels._ID)))
+                            .withValues(contentValue)
+                            .build()
+            );
+        }
+
+        return contentProviderOperations;
+    }
+
+    public static ArrayList<ContentProviderOperation> convertToInsertContentProviderOperation(List<ContentValues> contentValues) {
+        ArrayList<ContentProviderOperation> contentProviderOperations = new ArrayList<>();
+
+        for (ContentValues contentValue : contentValues) {
+            contentProviderOperations.add(
+                    ContentProviderOperation
+                            .newInsert(TvContract.Channels.CONTENT_URI)
+                            .withValues(contentValue)
+                            .build()
+            );
+        }
+
+        return contentProviderOperations;
+    }
+
+    public static ArrayList<ContentProviderOperation> convertToDeleteContentProviderOperation(List<Long> channelsIds) {
+        ArrayList<ContentProviderOperation> contentProviderOperations = new ArrayList<>();
+
+        for (Long id : channelsIds) {
+            contentProviderOperations.add(
+                    ContentProviderOperation
+                            .newDelete(TvContract.buildChannelUri(id))
+                            .build()
+            );
+        }
+
+        return contentProviderOperations;
+    }
+}

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/utils/TifExtensionChannel.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/utils/TifExtensionChannel.java
@@ -1,5 +1,7 @@
 package com.google.android.media.tv.companionlibrary.utils;
 
+import android.content.ContentValues;
+
 import com.google.android.media.tv.companionlibrary.model.TifExtension;
 
 /**
@@ -30,6 +32,24 @@ public class TifExtensionChannel {
      * @return The value of {@link TifExtension} for the channel.
      */
     public TifExtension getTifExtension() { return tifExtension; }
+
+    /**
+     * @return The fields of the TifExtension channel in the ContentValues format to be easily
+     * inserted into the TV Input Framework database.
+     */
+    public ContentValues toContentValues() {
+        ContentValues contentValues = new ContentValues();
+
+        contentValues.put(TifExtensionContract.Channels.COLUMN_CHANNEL_ID, channelId);
+
+        contentValues.put(TifExtensionContract.Channels.COLUMN_INPUT_ID, inputId);
+        if (getTifExtension().getGenre() != null) {
+            contentValues.put(TifExtensionContract.Channels.COLUMN_GENRE,
+                    getTifExtension().getGenre());
+        }
+
+        return contentValues;
+    }
 
     public static class Builder {
         private String inputId;

--- a/AndroidTvSampleInput/library/src/test/java/com/google/android/media/tv/companionlibrary/utils/ChannelDaoTest.java
+++ b/AndroidTvSampleInput/library/src/test/java/com/google/android/media/tv/companionlibrary/utils/ChannelDaoTest.java
@@ -1,0 +1,130 @@
+package com.google.android.media.tv.companionlibrary.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+
+import com.google.android.media.tv.companionlibrary.model.Channel;
+import com.google.android.media.tv.companionlibrary.model.TifExtension;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChannelDaoTest {
+
+    private ContentResolver contentResolver;
+    private List<TifExtensionChannel> channels;
+    private final ArgumentCaptor<ContentValues[]> contentValuesArgumentCaptor = ArgumentCaptor.forClass(ContentValues[].class);
+    private final ArgumentCaptor<Uri> uriArgumentCaptor = ArgumentCaptor.forClass(Uri.class);
+    private Cursor cursor;
+
+    @Before
+    public void setup() {
+        contentResolver = mock(ContentResolver.class);
+        when(contentResolver.bulkInsert(any(Uri.class), any(ContentValues[].class)))
+                .thenReturn(0);
+
+        channels = new ArrayList<>();
+        channels.add(new TifExtensionChannel
+                .Builder()
+                .setTifExtension(new TifExtension
+                        .Builder()
+                        .setGenre("Sports")
+                        .build())
+                .build()
+        );
+
+        cursor = mock(Cursor.class);
+        when(cursor.moveToNext())
+                .thenReturn(true)
+                .thenReturn(false);
+        when(cursor.isNull(anyInt()))
+                .thenReturn(false);
+        when(cursor.getLong(anyInt()))
+                .thenReturn(1L);
+        when(cursor.getString(anyInt()))
+                .thenReturn("description")
+                .thenReturn("displayName")
+                .thenReturn("displayNumber")
+                .thenReturn("inputId")
+                .thenReturn("networkAffiliation")
+                .thenReturn("packageName")
+                .thenReturn("serviceType")
+                .thenReturn("type")
+                .thenReturn("videoFormat");
+        when(cursor.getBlob(anyInt()))
+                .thenReturn("test".getBytes());
+        when(cursor.getInt(anyInt()))
+                .thenReturn(2);
+
+    }
+
+    @Test
+    public void testInsertChannels() {
+        ChannelDao.insertTifExtensionChannels(contentResolver, channels);
+        verify(contentResolver).bulkInsert(uriArgumentCaptor.capture(), contentValuesArgumentCaptor.capture());
+        assertEquals(TifExtensionContract.Channels.CONTENT_URI, uriArgumentCaptor.getValue());
+        assertEquals(1, contentValuesArgumentCaptor.getAllValues().get(0).length);
+    }
+
+    @Test
+    public void testGetAllChannels() {
+        when(contentResolver.query(any(Uri.class), any(String[].class), any(String.class), any(String[].class), any(String.class)))
+                .thenReturn(cursor);
+
+        when(cursor.getCount())
+                .thenReturn(1);
+
+        List<Channel> channels = ChannelDao.getAllChannels(contentResolver);
+        assertEquals(1, channels.size());
+        Channel actualChannel = channels.get(0);
+        assertEquals(1L, actualChannel.getId());
+        assertEquals("description", actualChannel.getDescription());
+        assertEquals("displayName", actualChannel.getDisplayName());
+        assertEquals("displayNumber", actualChannel.getDisplayNumber());
+        assertEquals("inputId", actualChannel.getInputId());
+        assertEquals("test", new String(actualChannel.getInternalProviderDataByteArray()));
+        assertEquals("networkAffiliation", actualChannel.getNetworkAffiliation());
+        assertEquals(2, actualChannel.getOriginalNetworkId());
+        assertEquals("packageName", actualChannel.getPackageName());
+        assertFalse(actualChannel.isSearchable());
+        assertEquals(2, actualChannel.getServiceId());
+        assertEquals("serviceType", actualChannel.getServiceType());
+        assertEquals(2, actualChannel.getTransportStreamId());
+        assertEquals("type", actualChannel.getType());
+        assertEquals("videoFormat", actualChannel.getVideoFormat());
+    }
+
+    @Test
+    public void testGetAllChannelsNoResults() {
+        when(cursor.getCount())
+                .thenReturn(0);
+        when(contentResolver.query(any(Uri.class), any(String[].class), any(String.class), any(String[].class), any(String.class)))
+                .thenReturn(cursor);
+
+        List<Channel> channels = ChannelDao.getAllChannels(contentResolver);
+        assertEquals(0, channels.size());
+
+    }
+
+    @Test
+    public void testGetAllChannelsNullCursor() {
+        when(contentResolver.query(any(Uri.class), any(String[].class), any(String.class), any(String[].class), any(String.class)))
+                .thenReturn(null);
+        assertNull(ChannelDao.getAllChannels(contentResolver));
+    }
+}


### PR DESCRIPTION
*Description of changes:*

- Will only add new channels if they dont exist, or update channels if there is a difference between the object fields. Previously all channels would get updated every time a sync was triggered

- Leveraging bulk operation i.e. `contentResolver.applyBatch(...)` for CRUD operations against channel table in TIF database

-  Breaking out functionality from `TvContractUtils.java` into classes such as `ChannelDao.java` and `ConverterUtils.java`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
