### PR TITLE
Add support for media playback in Gracenote example channels

### DIFF
--- a/AndroidTvSampleInput/app/src/main/java/com/example/android/sampletvinput/MainFragment.java
+++ b/AndroidTvSampleInput/app/src/main/java/com/example/android/sampletvinput/MainFragment.java
@@ -38,7 +38,7 @@ import com.example.android.sampletvinput.rich.RichTvInputSetupActivity;
  */
 public class MainFragment extends Fragment {
 
-    public static final String AMAZON_LIVE_TV_DEV_INTEGRATION_URL = "https://developer.amazon.com/docs/fire-tv/live-tv-integration.html";
+    public static final String AMAZON_LIVE_TV_DEV_INTEGRATION_URL = "https://developer.amazon.com/docs/fire-tv/introduction-linear-tv-integration.html";
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/BaseTvInputService.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/BaseTvInputService.java
@@ -461,11 +461,11 @@ public abstract class BaseTvInputService extends TvInputService {
         private boolean playCurrentProgram() {
             if (mCurrentProgram == null) {
                 Log.w(TAG, "Failed to get program info for " + mChannelUri + ". Try to do an " +
-                            "EPG sync.");
-                return onPlayProgram(null, 0);
+                            "EPG sync. This may be expected if this is a Gracenote channel.");
+                return onPlayProgram(null, 0, mCurrentChannel);
             }
             calculateElapsedTimesFromCurrentTime();
-            return onPlayProgram(mCurrentProgram, mElapsedProgramTime);
+            return onPlayProgram(mCurrentProgram, mElapsedProgramTime, mCurrentChannel);
         }
 
         private void playCurrentChannel() {
@@ -484,11 +484,17 @@ public abstract class BaseTvInputService extends TvInputService {
          * {@code null}. Developers should check the null condition and handle that case, possibly
          * by manually resyncing the EPG.
          *
+         * If program metadata is being provided externally for a channel (i.e. via Gracenote) there
+         * may be no corresponding current program in the TIF database. The tuned channel is provided
+         * so that developers can determine if a {@code null} value for {@code program} represents
+         * an error or not in these cases.
+         *
          * @param program The program that is set to be playing for a the currently tuned channel.
          * @param startPosMs Start position of content video.
+         * @param channel The currently tuned channel.
          * @return Whether playing this program was successful.
          */
-        public abstract boolean onPlayProgram(Program program, long startPosMs);
+        public abstract boolean onPlayProgram(Program program, long startPosMs, Channel channel);
 
         /**
          * This method is called when the user tunes to a given channel. Developers can override

--- a/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/model/InternalProviderData.java
+++ b/AndroidTvSampleInput/library/src/main/java/com/google/android/media/tv/companionlibrary/model/InternalProviderData.java
@@ -191,6 +191,21 @@ public class InternalProviderData {
     }
 
     /**
+     * Gets the external ID type for the channel.
+     *
+     * @return The external ID type
+     */
+    public String getExternalIdType() {
+        if (mJsonObject.has(KEY_AMZN_EXTERNAL_ID_TYPE)) {
+            try {
+                return mJsonObject.getString(KEY_AMZN_EXTERNAL_ID_TYPE);
+            } catch (JSONException ignored) {
+            }
+        }
+        return null;
+    }
+
+    /**
      * Sets the external ID value for the channel. Both type and value must be set.
      *
      * @param externalIdValue The external ID value


### PR DESCRIPTION
*Description of changes:*

- Added support for launching media playback when the user tunes to a Gracenote example channel.
- Added playback of a test data stream for the Gracenote example channels.
- Fixed broken link to Amazon Fire TV Live TV developer documentation shown when opening sample app.
- Improved some error messages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
